### PR TITLE
add data quality code and annotations to time series export

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,17 +16,16 @@ imported as long as data logger file columns and results are properly
 setup.
 ODM2 can be found here: https://github.com/ODM2
 
-In the folder templatesAndSettings you will find ``settings.py`` which
-contains all of the database and local file system settings which need
-to be configured to get a copy of this application working. This was
-developed using a postgresql version of ODM2 data model, additional
-modifications will be needed to make this work with MSSQL or another
-database.
+The file ``settings.yaml`` contains all of the database and local
+file system settings which need to be configured to get a copy of this
+application working. This was developed using a postgresql version of
+ODM2 data model, additional modifications will be needed to make this
+work with MSSQL or another database.
 
-An example postgresqldatabase named ODM2AdminExamplePostgresqlDB, this
-is a custom postgresql format backup which can be restored to an empty
-database. An extrasql.sql file contains some extra views used for 
-efficiently exporting data as emails. 
+An example postgresql database named ODM2AdminExamplePostgresqlDB is
+provided, this is a custom postgresql format backup which can be
+restored to an empty database. An extrasql.sql file contains some extra
+views used for efficiently exporting data as emails.
 
 
 **Primary Installation**

--- a/extrasql.sql
+++ b/extrasql.sql
@@ -129,34 +129,35 @@ ALTER TABLE odm2extra.timeseriesresultvaluesext
   OWNER TO postgres;
 
 CREATE OR REPLACE VIEW odm2extra.timeseriesresultvaluesextwannotations AS 
- SELECT timeseriesresultvalues.valueid,
-    timeseriesresultvalues.datavalue,
-    timeseriesresultvalues.valuedatetime,
-    timeseriesresultvalues.valuedatetimeutcoffset,
-    timeseriesresultvalues.censorcodecv,
-    timeseriesresultvalues.qualitycodecv,
-    timeseriesresultvalues.timeaggregationinterval,
-    timeseriesresultvalues.timeaggregationintervalunitsid,
+ SELECT tsrv.valueid,
+    tsrv.datavalue,
+    tsrv.valuedatetime,
+    tsrv.valuedatetimeutcoffset,
+    tsrv.censorcodecv,
+    tsrv.qualitycodecv,
+    tsrv.timeaggregationinterval,
+    tsrv.timeaggregationintervalunitsid,
     samplingfeatures.samplingfeaturename,
+    samplingfeatures.samplingfeaturetypecv,
     processinglevels.processinglevelcode,
     variables.variablecode,
     units.unitsabbreviation,
-    timeseriesresultvalues.resultid,
+    tsrv.resultid,
     cv_aggregationstatistic.name AS aggregationstatisticname,
-    annotations.annotationtext
-   FROM odm2.timeseriesresultvalues,
-    odm2.timeseriesresults,
+    b.annotationtext
+   FROM odm2.timeseriesresultvalues tsrv
+     LEFT JOIN odm2.timeseriesresultvalueannotations a ON tsrv.valueid = a.valueid
+     LEFT JOIN odm2.annotations b ON a.annotationid = b.annotationid,
     odm2.results,
+    odm2.timeseriesresults,
     odm2.featureactions,
     odm2.samplingfeatures,
     odm2.processinglevels,
     odm2.variables,
     odm2.units,
-    odm2.cv_aggregationstatistic,
-    odm2.timeseriesresultvalueannotations,
-    odm2.annotations
-  WHERE timeseriesresultvalues.resultid = timeseriesresults.resultid AND timeseriesresultvalues.valueid = timeseriesresultvalueannotations.valueid AND timeseriesresults.resultid = results.resultid AND timeseriesresults.aggregationstatisticcv::text = cv_aggregationstatistic.name::text AND results.featureactionid = featureactions.featureactionid AND results.processinglevelid = processinglevels.processinglevelid AND results.variableid = variables.variableid AND results.unitsid = units.unitsid AND featureactions.samplingfeatureid = samplingfeatures.samplingfeatureid AND timeseriesresultvalueannotations.annotationid = annotations.annotationid
-  ORDER BY timeseriesresultvalues.datavalue DESC;
+    odm2.cv_aggregationstatistic
+  WHERE tsrv.resultid = timeseriesresults.resultid AND timeseriesresults.resultid = results.resultid AND timeseriesresults.aggregationstatisticcv::text = cv_aggregationstatistic.name::text AND results.featureactionid = featureactions.featureactionid AND results.processinglevelid = processinglevels.processinglevelid AND results.variableid = variables.variableid AND results.unitsid = units.unitsid AND featureactions.samplingfeatureid = samplingfeatures.samplingfeatureid
+  ORDER BY tsrv.datavalue DESC;
 
 ALTER TABLE odm2extra.timeseriesresultvaluesextwannotations
   OWNER TO postgres;

--- a/odm2admin/NewProcessinglevelForTimeSeries.py
+++ b/odm2admin/NewProcessinglevelForTimeSeries.py
@@ -6,10 +6,10 @@ application = get_wsgi_application()
 
 from datetime import datetime
 import warnings
-import ODM2CZOData.modelHelpers as modelHelpers
-from ODM2CZOData.models import Timeseriesresults
-from ODM2CZOData.models import Timeseriesresultvalues
-from ODM2CZOData.models import Processinglevels
+import odm2admin.modelHelpers as modelHelpers
+from odm2admin.models import Timeseriesresults
+from odm2admin.models import Timeseriesresultvalues
+from odm2admin.models import Processinglevels
 
 
 # range 0 to 26.7

--- a/odm2admin/forms.py
+++ b/odm2admin/forms.py
@@ -459,8 +459,11 @@ class VariablesAdminForm(ModelForm):
     # variablenamecv= TermModelChoiceField(CvVariablename.objects.all().order_by('term'))
     # speciationcv= TermModelChoiceField(CvSpeciation.objects.all().order_by('term'))
     # make these fields ajax type ahead fields with links to odm2 controlled vocabulary
-    variable_type = make_ajax_field(Variables, 'variable_type', 'cv_variable_type')
-    variable_name = make_ajax_field(Variables, 'variable_name', 'cv_variable_name')
+    variable_type = AutoCompleteSelectField('cv_variable_type', required=True, label='variable type')
+    #AutoCompleteSelectField('featureaction_lookup', required=True, help_text='',
+    #                                          label='Sampling feature action')
+    variable_name = AutoCompleteSelectField('cv_variable_name', required=True, label = 'variable name')
+    #make_ajax_field(Variables, 'variable_name', 'cv_variable_name')
     variabledefinition = forms.CharField(max_length=500, widget=forms.Textarea)
     # variable_type = make_ajax_field(Variables,'variable_type','cv_variable_type')
     speciation = make_ajax_field(Variables, 'speciation', 'cv_speciation')

--- a/odm2admin/management/commands/ProcessDataLoggerFile.py
+++ b/odm2admin/management/commands/ProcessDataLoggerFile.py
@@ -91,7 +91,6 @@ class Command(BaseCommand):
         parser.add_argument('check_dates', nargs=1, type=bool)
         parser.add_argument('cmdline', nargs=1, type=bool)
 
-    @transaction.atomic
     def handle(self, *args, **options):  # (f,fileid, databeginson,columnheaderson, cmd):
         # cmdline = bool(options['cmdline'][0])
         filename = str(options['dataloggerfilelink'][0])
@@ -244,58 +243,64 @@ class Command(BaseCommand):
                                             qualitycode = qualitycodegood
                                             if dataqualitybool:
                                                 if newdatavalue > result_upper_bound.dataqualityvalue:
-                                                    annotationtext = result_upper_bound.dataqualitycode + \
-                                                        " of " + str(result_upper_bound.dataqualityvalue) \
-                                                        + " exceeded, raw value was " + str(newdatavalue)
-                                                    annotation= Annotations(annotationtypecv=annotationtypecv,
-                                                            annotationcode="Value out of Range: High",
-                                                            annotationtext=annotationtext,
-                                                            annotationdatetime=annotationdatetime,
-                                                            annotationutcoffset=4, annotatorid=annotatorid)
-                                                    annotation.save()
-                                                    tsvr = Timeseriesresultvalues(
-                                                        resultid=mresults,
-                                                        datavalue=newdatavalue,
-                                                        valuedatetime=datestr,
-                                                        valuedatetimeutcoffset=4,
-                                                        censorcodecv=censorcode,
-                                                        qualitycodecv=qualitycode,
-                                                        timeaggregationinterval=mresults
-                                                        .intendedtimespacing,
-                                                        timeaggregationintervalunitsid=mresults
-                                                        .intendedtimespacingunitsid
-                                                        ).save()
-                                                    tsrva = Timeseriesresultvalueannotations(valueid=tsvr,
-                                                                                     annotationid=annotation).save()
-                                                    newdatavalue =float('NaN')
-                                                    qualitycode = qualitycodebad
+                                                    with transaction.atomic():
+                                                        annotationtext = result_upper_bound.dataqualitycode + \
+                                                            " of " + str(result_upper_bound.dataqualityvalue) \
+                                                            + " exceeded, raw value was " + str(newdatavalue)
+                                                        annotation= Annotations(annotationtypecv=annotationtypecv,
+                                                                annotationcode="Value out of Range: High",
+                                                                annotationtext=annotationtext,
+                                                                annotationdatetime=annotationdatetime,
+                                                                annotationutcoffset=4, annotatorid=annotatorid)
+                                                        newdatavalue =float('NaN')
+                                                        qualitycode = qualitycodebad
+                                                        tsvr = Timeseriesresultvalues(
+                                                            resultid=mresults,
+                                                            datavalue=newdatavalue,
+                                                            valuedatetime=datestr,
+                                                            valuedatetimeutcoffset=4,
+                                                            censorcodecv=censorcode,
+                                                            qualitycodecv=qualitycode,
+                                                            timeaggregationinterval=mresults
+                                                            .intendedtimespacing,
+                                                            timeaggregationintervalunitsid=mresults
+                                                            .intendedtimespacingunitsid
+                                                            )
+                                                        annotation.save()
+                                                        tsvr.save()
+                                                        tsrva = Timeseriesresultvalueannotations(valueid=tsvr,
+                                                                                         annotationid=annotation).save()
+
                                                 elif newdatavalue < result_lower_bound.dataqualityvalue:
-                                                    annotationtext = "value below " + \
-                                                        result_lower_bound.dataqualitycode + \
-                                                        " of " + str(result_lower_bound.dataqualityvalue) \
-                                                        + ", raw value was " + str(newdatavalue)
-                                                    annotation= Annotations(annotationtypecv=annotationtypecv,
-                                                            annotationcode="Value out of Range: Low",
-                                                            annotationtext=annotationtext,
-                                                            annotationdatetime=annotationdatetime,
-                                                            annotationutcoffset=4, annotatorid=annotatorid)
-                                                    annotation.save()
-                                                    tsvr = Timeseriesresultvalues(
-                                                        resultid=mresults,
-                                                        datavalue=newdatavalue,
-                                                        valuedatetime=datestr,
-                                                        valuedatetimeutcoffset=4,
-                                                        censorcodecv=censorcode,
-                                                        qualitycodecv=qualitycode,
-                                                        timeaggregationinterval=mresults
-                                                        .intendedtimespacing,
-                                                        timeaggregationintervalunitsid=mresults
-                                                        .intendedtimespacingunitsid
-                                                        ).save()
-                                                    tsrva = Timeseriesresultvalueannotations(valueid=tsvr,
-                                                                                     annotationid=annotation).save()
-                                                    newdatavalue =float('NaN')
-                                                    qualitycode = qualitycodebad
+                                                    with transaction.atomic():
+                                                        annotationtext = "value below " + \
+                                                            result_lower_bound.dataqualitycode + \
+                                                            " of " + str(result_lower_bound.dataqualityvalue) \
+                                                            + ", raw value was " + str(newdatavalue)
+                                                        annotation= Annotations(annotationtypecv=annotationtypecv,
+                                                                annotationcode="Value out of Range: Low",
+                                                                annotationtext=annotationtext,
+                                                                annotationdatetime=annotationdatetime,
+                                                                annotationutcoffset=4, annotatorid=annotatorid)
+
+                                                        newdatavalue =float('NaN')
+                                                        qualitycode = qualitycodebad
+                                                        tsvr = Timeseriesresultvalues(
+                                                            resultid=mresults,
+                                                            datavalue=newdatavalue,
+                                                            valuedatetime=datestr,
+                                                            valuedatetimeutcoffset=4,
+                                                            censorcodecv=censorcode,
+                                                            qualitycodecv=qualitycode,
+                                                            timeaggregationinterval=mresults
+                                                            .intendedtimespacing,
+                                                            timeaggregationintervalunitsid=mresults
+                                                            .intendedtimespacingunitsid
+                                                            )
+                                                        annotation.save()
+                                                        tsvr.save()
+                                                        tsrva = Timeseriesresultvalueannotations(valueid=tsvr,
+                                                                                         annotationid=annotation).save()
                                                 else:
                                                     dataqualitybool = False
                                             # print(row[colnum.columnnum])

--- a/odm2admin/management/commands/ProcessDataLoggerFile.py
+++ b/odm2admin/management/commands/ProcessDataLoggerFile.py
@@ -232,14 +232,16 @@ class Command(BaseCommand):
                     # Timeseriesresults.objects.raw("SELECT odm2.\
                     # "TimeseriesresultValsToResultsCountvalue\"()")
             Timeseriesresultvalues.objects.bulk_create(bulktimeseriesvalues)
+            bulktimeseriesvalues = None
+
         except IndexError:
             raise ValidationError('encountered a problem with row ' + str(i) for i in row)
         bulkpropertyvals = []
         for colnum in rowColumnMap:
             results = Timeseriesresults.objects.filter(resultid=colnum.resultid)
             for result in results:
-                mrvs_count = len(Timeseriesresultvalues.objects.filter(resultid=result))
-                if mrvs_count > 0:
+                mrvsexist = Timeseriesresultvalues.objects.filter(resultid=result).exists()
+                if mrvsexist:
                     startdate = Timeseriesresultvalues.objects.filter(resultid=result).annotate(
                         Min('valuedatetime')). \
                         order_by('valuedatetime')[0].valuedatetime.strftime(

--- a/odm2admin/management/commands/ProcessDataLoggerFile.py
+++ b/odm2admin/management/commands/ProcessDataLoggerFile.py
@@ -174,7 +174,7 @@ class Command(BaseCommand):
                         #         resultid__in=DataloggerfilecolumnSet.values("resultid"))
                         #     mrvs = Timeseriesresultvalues.objects.filter(resultid__in=mrs)
                         for colnum in rowColumnMap:
-                            dataqualitybool = False
+                            dataqualitybool = True
                             # this assumes that the first column is the date and time
                             if not colnum.columnnum == 0:
                                 # raise ValidationError("result: " + str(colnum.resultid) +
@@ -189,11 +189,11 @@ class Command(BaseCommand):
                                 try:
                                     resultsdataquality = Resultsdataquality.objects.filter(resultid=colnum.resultid)
                                     dataquality = Dataquality.objects.filter(
-                                        dataqualityid=resultsdataquality.values('dataqualityid'))
+                                        dataqualityid__in=resultsdataquality.values('dataqualityid'))
                                     #assumption only one upper bound and one lower bound per result
-                                    result_upper_bound = dataquality.filter(dataqualityid=dataquality).get(
+                                    result_upper_bound = dataquality.get(
                                         dataqualitytypecv=upper_bound_quality_type)
-                                    result_lower_bound = dataquality.filter(dataqualityid=dataquality).get(
+                                    result_lower_bound = dataquality.get(
                                         dataqualitytypecv=lower_bound_quality_type)
                                     annotationtypecv = CvAnnotationtype.objects.filter(
                                         name="Time series result value annotation").get()
@@ -245,8 +245,8 @@ class Command(BaseCommand):
                                             if dataqualitybool:
                                                 if newdatavalue > result_upper_bound.dataqualityvalue:
                                                     annotationtext = result_upper_bound.dataqualitycode + \
-                                                        " of " + result_upper_bound.dataqualityvalue \
-                                                        + " exceeded, raw value was " + newdatavalue
+                                                        " of " + str(result_upper_bound.dataqualityvalue) \
+                                                        + " exceeded, raw value was " + str(newdatavalue)
                                                     bulkannotations.append(
                                                         Annotations(annotationtypecv=annotationtypecv,
                                                             annotationcode="Value out of Range: High",
@@ -258,8 +258,8 @@ class Command(BaseCommand):
                                                 if newdatavalue < result_lower_bound.dataqualityvalue:
                                                     annotationtext = "value below " + \
                                                         result_lower_bound.dataqualitycode + \
-                                                        " of " + result_lower_bound.dataqualityvalue \
-                                                        + ", raw value was " + newdatavalue
+                                                        " of " + str(result_lower_bound.dataqualityvalue) \
+                                                        + ", raw value was " + str(newdatavalue)
                                                     bulkannotations.append(
                                                         Annotations(annotationtypecv=annotationtypecv,
                                                             annotationcode="Value out of Range: Low",

--- a/odm2admin/management/commands/ProcessDataLoggerFile.py
+++ b/odm2admin/management/commands/ProcessDataLoggerFile.py
@@ -15,14 +15,14 @@ from django.db import IntegrityError
 from django.db import transaction
 from django.db.models import Min, Max
 
-from ODM2CZOData.models import CvCensorcode
-from ODM2CZOData.models import CvQualitycode
-from ODM2CZOData.models import Dataloggerfilecolumns
-from ODM2CZOData.models import Dataloggerfiles
-from ODM2CZOData.models import Extensionproperties
-from ODM2CZOData.models import Resultextensionpropertyvalues
-from ODM2CZOData.models import Timeseriesresults
-from ODM2CZOData.models import Timeseriesresultvalues
+from odm2admin.models import CvCensorcode
+from odm2admin.models import CvQualitycode
+from odm2admin.models import Dataloggerfilecolumns
+from odm2admin.models import Dataloggerfiles
+from odm2admin.models import Extensionproperties
+from odm2admin.models import Resultextensionpropertyvalues
+from odm2admin.models import Timeseriesresults
+from odm2admin.models import Timeseriesresultvalues
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "templatesAndSettings.settings")
 
@@ -49,31 +49,31 @@ def updateStartDateEndDate(results, startdate, enddate):
     StartDateProperty = Extensionproperties.objects.get(propertyname__icontains="start date")
     EndDateProperty = Extensionproperties.objects.get(propertyname__icontains="end date")
     # result = results#.objects.get(resultid=results.resultid.resultid)
-    repvstart = None
-    repvend = None
-    try:
+    if Resultextensionpropertyvalues.objects.filter(resultid=results.resultid).filter(
+            propertyid=StartDateProperty).exists() and Resultextensionpropertyvalues.objects.filter(resultid=results.resultid).filter(
+            propertyid=EndDateProperty).exists():
         # raise CommandError(" start date "str(startdate)))
         #
-        repvstart = Resultextensionpropertyvalues.objects.filter(resultid=results.resultid).filter(
-            propertyid=StartDateProperty) #.update(propertyvalue=startdate)
-        repvstart.propertyvalue=startdate
+        Resultextensionpropertyvalues.objects.filter(resultid=results.resultid).filter(
+            propertyid=StartDateProperty).update(propertyvalue=startdate)
+        # repvstart.propertyvalue=startdate
 
-        repvend = Resultextensionpropertyvalues.objects.filter(resultid=results.resultid).filter(
-            propertyid=EndDateProperty) #.update(propertyvalue=enddate)
-        repvend.prepertyvalue = enddate
+        Resultextensionpropertyvalues.objects.filter(resultid=results.resultid).filter(
+            propertyid=EndDateProperty).update(propertyvalue=enddate)
+        # repvend.propertyvalue = enddate
 
-    except ObjectDoesNotExist:
+    else:
         # raise CommandError("couldn't find extension property values " +str(repvstart) + "for " +
         # str(StartDateProperty + "for" + str(results))
         repvstart = Resultextensionpropertyvalues(resultid=results, propertyid=StartDateProperty,
                                                   propertyvalue=startdate)
         # print(repvstart.propertyvalue)
-        #repvstart.save()
+        repvstart.save()
         repvend = Resultextensionpropertyvalues(resultid=results, propertyid=EndDateProperty,
                                                 propertyvalue=enddate)
         # print(repvend.propertyvalue)
-        #repvend.save()
-    return repvstart, repvend
+        repvend.save()
+    # return repvstart, repvend
 
 
 class Command(BaseCommand):
@@ -249,8 +249,8 @@ class Command(BaseCommand):
                     enddate = Timeseriesresultvalues.objects.filter(resultid=result).annotate(
                         Max('valuedatetime')). \
                         order_by('-valuedatetime')[0].valuedatetime.strftime('%Y-%m-%d %H:%M')
-                    repvstart, repvend = updateStartDateEndDate(result, startdate, enddate)
-                    bulkpropertyvals.append(repvstart)
-                    bulkpropertyvals.append(repvend)
-        #will bulk create or update the property values
-        Resultextensionpropertyvalues.objects.bulk_create(bulkpropertyvals)
+                    updateStartDateEndDate(result, startdate, enddate) # repvstart, repvend =
+                    # bulkpropertyvals.append(repvstart)
+                    # bulkpropertyvals.append(repvend)
+        # will bulk create or update the property values
+        # Resultextensionpropertyvalues.objects.bulk_create(bulkpropertyvals)

--- a/odm2admin/management/commands/ProcessDataLoggerFile.py
+++ b/odm2admin/management/commands/ProcessDataLoggerFile.py
@@ -103,8 +103,6 @@ class Command(BaseCommand):
         columnheaderson = int(options['columnheaderson'][0])  # int(columnheaderson[0])
         rowColumnMap = list()
         bulktimeseriesvalues = []
-        bulkannotations = []
-        bulktimeseriesresultvalueannotations = []
         upper_bound_quality_type = CvDataqualitytype.objects.get(name = 'Physical limit upper bound')
         lower_bound_quality_type = CvDataqualitytype.objects.get(name = 'Physical limit lower bound')
         try:
@@ -254,7 +252,21 @@ class Command(BaseCommand):
                                                             annotationtext=annotationtext,
                                                             annotationdatetime=annotationdatetime,
                                                             annotationutcoffset=4, annotatorid=annotatorid)
-                                                    bulkannotations.append(annotation)
+                                                    annotation.save()
+                                                    tsvr = Timeseriesresultvalues(
+                                                        resultid=mresults,
+                                                        datavalue=newdatavalue,
+                                                        valuedatetime=datestr,
+                                                        valuedatetimeutcoffset=4,
+                                                        censorcodecv=censorcode,
+                                                        qualitycodecv=qualitycode,
+                                                        timeaggregationinterval=mresults
+                                                        .intendedtimespacing,
+                                                        timeaggregationintervalunitsid=mresults
+                                                        .intendedtimespacingunitsid
+                                                        ).save()
+                                                    tsrva = Timeseriesresultvalueannotations(valueid=tsvr,
+                                                                                     annotationid=annotation).save()
                                                     newdatavalue =float('NaN')
                                                     qualitycode = qualitycodebad
                                                 elif newdatavalue < result_lower_bound.dataqualityvalue:
@@ -267,7 +279,21 @@ class Command(BaseCommand):
                                                             annotationtext=annotationtext,
                                                             annotationdatetime=annotationdatetime,
                                                             annotationutcoffset=4, annotatorid=annotatorid)
-                                                    bulkannotations.append(annotation)
+                                                    annotation.save()
+                                                    tsvr = Timeseriesresultvalues(
+                                                        resultid=mresults,
+                                                        datavalue=newdatavalue,
+                                                        valuedatetime=datestr,
+                                                        valuedatetimeutcoffset=4,
+                                                        censorcodecv=censorcode,
+                                                        qualitycodecv=qualitycode,
+                                                        timeaggregationinterval=mresults
+                                                        .intendedtimespacing,
+                                                        timeaggregationintervalunitsid=mresults
+                                                        .intendedtimespacingunitsid
+                                                        ).save()
+                                                    tsrva = Timeseriesresultvalueannotations(valueid=tsvr,
+                                                                                     annotationid=annotation).save()
                                                     newdatavalue =float('NaN')
                                                     qualitycode = qualitycodebad
                                                 else:
@@ -275,24 +301,20 @@ class Command(BaseCommand):
                                             # print(row[colnum.columnnum])
                                             # check if values are above or below quality bounds
                                             # create an annotation if they are.
-                                            tsvr = Timeseriesresultvalues(
-                                                resultid=mresults,
-                                                datavalue=newdatavalue,
-                                                valuedatetime=datestr,
-                                                valuedatetimeutcoffset=4,
-                                                censorcodecv=censorcode,
-                                                qualitycodecv=qualitycode,
-                                                timeaggregationinterval=mresults
-                                                .intendedtimespacing,
-                                                timeaggregationintervalunitsid=mresults
-                                                .intendedtimespacingunitsid
-                                            )
-                                            bulktimeseriesvalues.append(tsvr)
-                                            if dataqualitybool:
-                                                bulktimeseriesresultvalueannotations.append(
-                                                    Timeseriesresultvalueannotations(valueid=tsvr,
-                                                                                     annotationid=annotation)
+                                            if not dataqualitybool:
+                                                tsvr = Timeseriesresultvalues(
+                                                    resultid=mresults,
+                                                    datavalue=newdatavalue,
+                                                    valuedatetime=datestr,
+                                                    valuedatetimeutcoffset=4,
+                                                    censorcodecv=censorcode,
+                                                    qualitycodecv=qualitycode,
+                                                    timeaggregationinterval=mresults
+                                                    .intendedtimespacing,
+                                                    timeaggregationintervalunitsid=mresults
+                                                    .intendedtimespacingunitsid
                                                 )
+                                                bulktimeseriesvalues.append(tsvr)
                                             # print("saved value")
                                     except IntegrityError:
                                         pass
@@ -302,8 +324,6 @@ class Command(BaseCommand):
                     # Timeseriesresults.objects.raw("SELECT odm2.\
                     # "TimeseriesresultValsToResultsCountvalue\"()")
             Timeseriesresultvalues.objects.bulk_create(bulktimeseriesvalues)
-            Annotations.objects.bulk_create(bulkannotations)
-            Timeseriesresultvalueannotations.bulk_create(bulktimeseriesresultvalueannotations)
             bulktimeseriesvalues = None
 
         except IndexError:

--- a/odm2admin/management/commands/ProcessDataLoggerFile.py
+++ b/odm2admin/management/commands/ProcessDataLoggerFile.py
@@ -49,9 +49,7 @@ def updateStartDateEndDate(results, startdate, enddate):
     StartDateProperty = Extensionproperties.objects.get(propertyname__icontains="start date")
     EndDateProperty = Extensionproperties.objects.get(propertyname__icontains="end date")
     # result = results#.objects.get(resultid=results.resultid.resultid)
-    if Resultextensionpropertyvalues.objects.filter(resultid=results.resultid).filter(
-            propertyid=StartDateProperty).exists() and Resultextensionpropertyvalues.objects.filter(resultid=results.resultid).filter(
-            propertyid=EndDateProperty).exists():
+    try:
         # raise CommandError(" start date "str(startdate)))
         #
         Resultextensionpropertyvalues.objects.filter(resultid=results.resultid).filter(
@@ -62,7 +60,7 @@ def updateStartDateEndDate(results, startdate, enddate):
             propertyid=EndDateProperty).update(propertyvalue=enddate)
         # repvend.propertyvalue = enddate
 
-    else:
+    except ObjectDoesNotExist:
         # raise CommandError("couldn't find extension property values " +str(repvstart) + "for " +
         # str(StartDateProperty + "for" + str(results))
         repvstart = Resultextensionpropertyvalues(resultid=results, propertyid=StartDateProperty,

--- a/odm2admin/management/commands/ProcessDataLoggerFile.py
+++ b/odm2admin/management/commands/ProcessDataLoggerFile.py
@@ -103,8 +103,8 @@ class Command(BaseCommand):
         rowColumnMap = list()
         bulktimeseriesvalues = []
         bulkannotations = []
-        upper_bound_quality_type = CvDataqualitytype.get(name = 'Physical limit upper bound')
-        lower_bound_quality_type = CvDataqualitytype.get(name = 'Physical limit lower bound')
+        upper_bound_quality_type = CvDataqualitytype.objects.get(name = 'Physical limit upper bound')
+        lower_bound_quality_type = CvDataqualitytype.objects.get(name = 'Physical limit lower bound')
         try:
             with io.open(file, 'rt', encoding='ascii') as f:
                 # reader = csv.reader(f)
@@ -191,8 +191,10 @@ class Command(BaseCommand):
                                     dataquality = Dataquality.objects.filter(
                                         dataqualityid=resultsdataquality.values('dataqualityid'))
                                     #assumption only one upper bound and one lower bound per result
-                                    result_upper_bound = dataquality.get(dataqualitytypecv=upper_bound_quality_type)
-                                    result_lower_bound = dataquality.get(dataqualitytypecv=lower_bound_quality_type)
+                                    result_upper_bound = dataquality.filter(dataqualityid=dataquality).get(
+                                        dataqualitytypecv=upper_bound_quality_type)
+                                    result_lower_bound = dataquality.filter(dataqualityid=dataquality).get(
+                                        dataqualitytypecv=lower_bound_quality_type)
                                     annotationtypecv = CvAnnotationtype.objects.filter(
                                         name="Time series result value annotation").get()
                                     annotationdatetime = datetime.now()

--- a/odm2admin/management/commands/export_timeseriesresultvaluesextwannotations.py
+++ b/odm2admin/management/commands/export_timeseriesresultvaluesextwannotations.py
@@ -11,9 +11,9 @@ import re
 from django.core.management.base import BaseCommand, CommandError
 from django.core.mail import EmailMessage
 from django.core import mail
-from ODM2CZOData.models import Timeseriesresultvaluesext
-from ODM2CZOData.models import Results
-from ODM2CZOData.models import Timeseriesresultvaluesextwannotations
+from odm2admin.models import Timeseriesresultvaluesext
+from odm2admin.models import Results
+from odm2admin.models import Timeseriesresultvaluesextwannotations
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "templatesAndSettings.settings")
 

--- a/odm2admin/modelHelpers.py
+++ b/odm2admin/modelHelpers.py
@@ -23,6 +23,9 @@ from odm2admin.models import CvQualitycode
 from odm2admin.models import CvRelationshiptype
 from odm2admin.models import CvResulttype
 from odm2admin.models import CvStatus
+from odm2admin.models import CvDataqualitytype
+from odm2admin.models import Dataquality
+from odm2admin.models import Timeseriesresults
 from odm2admin.models import Featureactions
 from odm2admin.models import Measurementresults
 from odm2admin.models import Measurementresultvalueannotations
@@ -33,11 +36,48 @@ from odm2admin.models import Profileresults
 from odm2admin.models import Profileresultvalues
 from odm2admin.models import Relatedfeatures
 from odm2admin.models import Results
+from odm2admin.models import Resultsdataquality
 from odm2admin.models import Samplingfeatures
 from odm2admin.models import Units
 from odm2admin.models import Variables
 
 __author__ = 'leonmi'
+
+
+def new_results_dataquality_upper_and_lower_bounds(unit, variable, upperbound, lowerbound, save=False):
+    upper_bound_quality_type = CvDataqualitytype.objects.get(name = 'Physical limit upper bound')
+    lower_bound_quality_type = CvDataqualitytype.objects.get(name = 'Physical limit lower bound')
+
+    lower_bound= Dataquality(dataqualitytypecv=lower_bound_quality_type,
+        dataqualitycode=str(variable.variablecode) + ' lower bound',
+        dataqualityvalue=lowerbound,dataqualityvalueunitsid=unit,
+        dataqualitydescription='lower bound for ' + str(variable.variablecode))
+    print(lower_bound)
+    if save:
+        lower_bound.save()
+    upper_bound= Dataquality(dataqualitytypecv=upper_bound_quality_type,
+        dataqualitycode=str(variable.variablecode) + ' upper bound',
+        dataqualityvalue=upperbound,dataqualityvalueunitsid=unit,
+        dataqualitydescription='lower bound for '+ str(variable.variablecode))
+    print(upper_bound)
+    if save:
+        upper_bound.save()
+
+    variables_results = Results.objects.filter(variableid=variable).filter(unitsid=unit).order_by('featureactionid')
+    print('number of series to add bounds for ' + str(variables_results.count()))
+    for variables_result in variables_results:
+        upper_bound_dq = Resultsdataquality(resultid=variables_result,dataqualityid=upper_bound)
+        lower_bound_dq = Resultsdataquality(resultid=variables_result,dataqualityid=lower_bound)
+        print(upper_bound_dq)
+        print(lower_bound_dq)
+        if save:
+            upper_bound_dq.save()
+            lower_bound_dq.save()
+
+    variable_data_quality=Resultsdataquality.objects.filter(resultid__in=variables_results)
+
+    for varq in variable_data_quality:
+        print(varq)
 
 
 # searchTextString = some string to search a models charField for
@@ -339,3 +379,5 @@ def importValues(file, variableFileIndex, variableDBID, variableUnitID, actionID
             print(presultvalue)
             if save:
                 presultvalue.save()
+
+

--- a/odm2admin/modelHelpers.py
+++ b/odm2admin/modelHelpers.py
@@ -13,29 +13,29 @@ from django.core.exceptions import MultipleObjectsReturned
 from django.db import transaction
 from django.db.models import Q
 
-from ODM2CZOData.models import Actions
-from ODM2CZOData.models import Annotations
-from ODM2CZOData.models import CvAggregationstatistic
-from ODM2CZOData.models import CvAnnotationtype
-from ODM2CZOData.models import CvCensorcode
-from ODM2CZOData.models import CvMedium
-from ODM2CZOData.models import CvQualitycode
-from ODM2CZOData.models import CvRelationshiptype
-from ODM2CZOData.models import CvResulttype
-from ODM2CZOData.models import CvStatus
-from ODM2CZOData.models import Featureactions
-from ODM2CZOData.models import Measurementresults
-from ODM2CZOData.models import Measurementresultvalueannotations
-from ODM2CZOData.models import Measurementresultvalues
-from ODM2CZOData.models import People
-from ODM2CZOData.models import Processinglevels
-from ODM2CZOData.models import Profileresults
-from ODM2CZOData.models import Profileresultvalues
-from ODM2CZOData.models import Relatedfeatures
-from ODM2CZOData.models import Results
-from ODM2CZOData.models import Samplingfeatures
-from ODM2CZOData.models import Units
-from ODM2CZOData.models import Variables
+from odm2admin.models import Actions
+from odm2admin.models import Annotations
+from odm2admin.models import CvAggregationstatistic
+from odm2admin.models import CvAnnotationtype
+from odm2admin.models import CvCensorcode
+from odm2admin.models import CvMedium
+from odm2admin.models import CvQualitycode
+from odm2admin.models import CvRelationshiptype
+from odm2admin.models import CvResulttype
+from odm2admin.models import CvStatus
+from odm2admin.models import Featureactions
+from odm2admin.models import Measurementresults
+from odm2admin.models import Measurementresultvalueannotations
+from odm2admin.models import Measurementresultvalues
+from odm2admin.models import People
+from odm2admin.models import Processinglevels
+from odm2admin.models import Profileresults
+from odm2admin.models import Profileresultvalues
+from odm2admin.models import Relatedfeatures
+from odm2admin.models import Results
+from odm2admin.models import Samplingfeatures
+from odm2admin.models import Units
+from odm2admin.models import Variables
 
 __author__ = 'leonmi'
 

--- a/odm2admin/models.py
+++ b/odm2admin/models.py
@@ -2184,6 +2184,14 @@ class Results(models.Model):
         #s += 'citation,'
 
         return s
+
+    def email_text(self):
+        s = '{0} -unit-{1}-processing level-{2} '.format(
+            self.variableid.variablecode,
+            self.unitsid.unitsname,
+            self.processing_level.processinglevelcode)
+        return s
+
     def csvheaderShort(self):
         s = '\" {0} -unit-{1}-processing level-{2}\",'.format(
             self.variableid.variablecode,
@@ -2705,11 +2713,19 @@ class Timeseriesresultvalues(models.Model):
         # s += ' {0}\"'.format(citation.citationlink)
         return s
 
+
+    def email_text(self):
+        s = '{0} -unit-{1}-processing level-{2} '.format(
+            self.resultid.resultid.variableid.variablecode,
+            self.resultid.resultid.unitsid.unitsname,
+            self.resultid.resultid.processing_level.processinglevelcode)
+        return s
+
     def csvheaderShort(self):
         s = '\" {0} -unit-{1}-processing level-{2}\",'.format(
             self.resultid.resultid.variableid.variablecode,
             self.resultid.resultid.unitsid.unitsname,
-            self.resultid.resultid.processing_level)
+            self.resultid.resultid.processing_level.processinglevelcode)
         s += 'quality code,'
         s += 'annotation,'
         return s
@@ -2777,6 +2793,13 @@ class Timeseriesresultvaluesext(models.Model):
         s += 'time aggregation unit,'
         #s += 'citation,'
 
+        return s
+    def email_text(self):
+        s = '{0} -unit-{1}-processing level-{2} '.format(
+            self.variablecode,
+            self.unitsabbreviation,
+            self.processinglevelcode)
+        s += 'location- {0}'.format(self.samplingfeaturename)
         return s
     def csvheaderShort(self):
         s = '\" {0} -unit-{1}-processing level-{2}\",'.format(
@@ -2877,11 +2900,19 @@ class Timeseriesresultvaluesextwannotations(models.Model):
         # s += ' {0}\"'.format(citation.citationlink)
         return s
 
+    def email_text(self):
+        s = '{0} -unit-{1}-processing level-{2} '.format(
+            self.variablecode,
+            self.unitsabbreviation,
+            self.processinglevelcode)
+        s += 'location- {0}'.format(self.samplingfeaturename)
+        return s
+
     def csvheaderShort(self):
         s = '\" {0} -unit-{1}-processing level-{2}\",'.format(
-            self.resultid.resultid.variableid.variablecode,
-            self.resultid.resultid.unitsid.unitsname,
-            self.resultid.resultid.processing_level)
+            self.variablecode,
+            self.unitsabbreviation,
+            self.processinglevelcode)
         s += 'quality code,'
         s += 'quality annotation,'
         return s
@@ -2889,8 +2920,10 @@ class Timeseriesresultvaluesextwannotations(models.Model):
     def csvoutputShort(self):
         s = '{0},'.format(self.datavalue)
         s += '{0},'.format(self.qualitycodecv)
-        s += '\"{0} \",'.format(self.annotationtext)
-        s += ','
+        if self.annotationtext:
+            s += '\"{0} \",'.format(self.annotationtext)
+        else:
+             s += ','
         return s
 
     class Meta:

--- a/odm2admin/models.py
+++ b/odm2admin/models.py
@@ -2670,6 +2670,7 @@ class Timeseriesresultvalues(models.Model):
     def __unicode__(self):
         s = u"%s " % self.resultid
         s += u"- %s" % self.datavalue
+        s += u"- %s" % self.qualitycodecv
         s += u"- %s" % self.valuedatetime
         return s
 
@@ -2705,16 +2706,18 @@ class Timeseriesresultvalues(models.Model):
         return s
 
     def csvheaderShort(self):
-        s = '\" {0} -unit-{1}-processing level-{2}\",annotation,'.format(
+        s = '\" {0} -unit-{1}-processing level-{2}\",data quality code,annotation,'.format(
             self.resultid.resultid.variableid.variablecode,
             self.resultid.resultid.unitsid.unitsname,
             self.resultid.resultid.processing_level)
+        s += 'quality code,'
         return s
 
     def csvoutputShort(self):
-        s = '{0}'.format(self.datavalue)
-        mrvannotation = Measurementresultvalueannotations.objects.filter(valueid=self.valueid)
-        annotations = Annotations.objects.filter(annotationid__in=mrvannotation)
+        s = '{0},'.format(self.datavalue)
+        s += '{0}'.format(self.qualitycodecv)
+        trvannotation = Timeseriesresultvalueannotations.objects.filter(valueid=self.valueid)
+        annotations = Annotations.objects.filter(annotationid__in=trvannotation)
         s += ',\"'
         for anno in annotations:
             s += '{0} '.format(anno)
@@ -2756,6 +2759,7 @@ class Timeseriesresultvaluesext(models.Model):
     def __unicode__(self):
         s = u"%s " % self.resultid
         s += u"- %s" % self.datavalue
+        s += u"- %s" % self.qualitycodecv
         s += u"- %s" % self.valuedatetime
         return s
 
@@ -2778,6 +2782,7 @@ class Timeseriesresultvaluesext(models.Model):
             self.variablecode,
             self.unitsabbreviation,
             self.processinglevelcode)
+        s += 'quality code,'
         return s
     def csvoutput(self):
         s = str(self.valueid)
@@ -2798,8 +2803,8 @@ class Timeseriesresultvaluesext(models.Model):
 
 
     def csvoutputShort(self):
-        s = '{0}'.format(self.datavalue)
-        s += ','
+        s = '{0},'.format(self.datavalue)
+        s += '{0},'.format(self.qualitycodecv)
         return s
 
     class Meta:
@@ -2837,6 +2842,7 @@ class Timeseriesresultvaluesextwannotations(models.Model):
     def __unicode__(self):
         s = u"%s " % self.resultid
         s += u"- %s" % self.datavalue
+        s += u"- %s" % self.qualitycodecv
         s += u"- %s" % self.valuedatetime
         return s
 
@@ -2875,16 +2881,14 @@ class Timeseriesresultvaluesextwannotations(models.Model):
             self.resultid.resultid.variableid.variablecode,
             self.resultid.resultid.unitsid.unitsname,
             self.resultid.resultid.processing_level)
+        s += 'quality code,'
+        s += 'quality annotation,'
         return s
 
     def csvoutputShort(self):
-        s = '{0}'.format(self.datavalue)
-        mrvannotation = Measurementresultvalueannotations.objects.filter(valueid=self.valueid)
-        annotations = Annotations.objects.filter(annotationid__in=mrvannotation)
-        s += ',\"'
-        for anno in annotations:
-            s += '{0} '.format(anno)
-        s += '\"'
+        s = '{0},'.format(self.datavalue)
+        s += '{0},'.format(self.qualitycodecv)
+        s += '\"{0} \",'.format(self.annotationtext)
         s += ','
         return s
 

--- a/odm2admin/models.py
+++ b/odm2admin/models.py
@@ -2706,11 +2706,12 @@ class Timeseriesresultvalues(models.Model):
         return s
 
     def csvheaderShort(self):
-        s = '\" {0} -unit-{1}-processing level-{2}\",data quality code,annotation,'.format(
+        s = '\" {0} -unit-{1}-processing level-{2}\",'.format(
             self.resultid.resultid.variableid.variablecode,
             self.resultid.resultid.unitsid.unitsname,
             self.resultid.resultid.processing_level)
         s += 'quality code,'
+        s += 'annotation,'
         return s
 
     def csvoutputShort(self):
@@ -2877,7 +2878,7 @@ class Timeseriesresultvaluesextwannotations(models.Model):
         return s
 
     def csvheaderShort(self):
-        s = '\" {0} -unit-{1}-processing level-{2}\",annotation,'.format(
+        s = '\" {0} -unit-{1}-processing level-{2}\",'.format(
             self.resultid.resultid.variableid.variablecode,
             self.resultid.resultid.unitsid.unitsname,
             self.resultid.resultid.processing_level)

--- a/odm2admin/views.py
+++ b/odm2admin/views.py
@@ -1855,6 +1855,7 @@ def emailspreadsheet2(request, resultValuesSeries, profileResult=True):
         unit = ''
         firstheader = True
         processingCode = None
+        lastResult = None
         resultValuesHeaders = resultValuesSeries.filter(
             ~Q(
                 sampling_feature_type="Ecological land classification"  # noqa
@@ -1869,6 +1870,7 @@ def emailspreadsheet2(request, resultValuesSeries, profileResult=True):
         )
         # .distinct("resultid__resultid__variableid","resultid__resultid__unitsid")
         for myresults in resultValuesHeaders:
+            lastResult = myresults
             lastVariable = variable
             variable = myresults.variablecode
             lastUnit = unit
@@ -1885,9 +1887,10 @@ def emailspreadsheet2(request, resultValuesSeries, profileResult=True):
                     myfile.write(myresults.csvheader())
                     firstheader = False
                 myfile.write(myresults.csvheaderShort())
-                emailtext = emailtext + ' - ' + myresults.csvheaderShort()
+                emailtext = emailtext + ' - ' + str(myresults)
                 # elif not lastUnit==unit:
                 # myfile.write(myresults.csvheaderShortUnitOnly())
+
         if profileResult:
             resultValuesSeries = resultValuesSeries.filter(
                 ~Q(
@@ -1914,6 +1917,7 @@ def emailspreadsheet2(request, resultValuesSeries, profileResult=True):
                 "processinglevelcode"
             )
         # myfile.write(lastResult.csvheaderShort())
+        emailtext = emailtext + ' - ' + str(lastResult)
         myfile.write('\n')
 
         samplingfeaturename = ''

--- a/odm2admin/views.py
+++ b/odm2admin/views.py
@@ -1887,7 +1887,7 @@ def emailspreadsheet2(request, resultValuesSeries, profileResult=True):
                     myfile.write(myresults.csvheader())
                     firstheader = False
                 myfile.write(myresults.csvheaderShort())
-                emailtext = emailtext + ' - ' + str(myresults)
+                emailtext = emailtext + ' - ' + str(myresults.email_text())
                 # elif not lastUnit==unit:
                 # myfile.write(myresults.csvheaderShortUnitOnly())
 
@@ -1917,7 +1917,7 @@ def emailspreadsheet2(request, resultValuesSeries, profileResult=True):
                 "processinglevelcode"
             )
         # myfile.write(lastResult.csvheaderShort())
-        emailtext = emailtext + ' - ' + str(lastResult)
+        emailtext = emailtext + ' - ' + str(lastResult.email_text())
         myfile.write('\n')
 
         samplingfeaturename = ''

--- a/odm2admin/views.py
+++ b/odm2admin/views.py
@@ -1218,12 +1218,12 @@ def email_data_from_graph(request):
                 entered_end_date = request.POST['endDate']
             if 'startDate' in request.POST:
                 entered_start_date = request.POST['startDate']
-            myresultSeriesExport = Timeseriesresultvaluesext.objects.all() \
+            myresultSeriesExport = Timeseriesresultvaluesextwannotations.objects.all() \
                     .filter(valuedatetime__gte=entered_start_date) \
                     .filter(valuedatetime__lte=entered_end_date) \
                     .filter(resultid__in=selectedMResultSeries).order_by('-valuedatetime')
         else:
-            myresultSeriesExport = Timeseriesresultvaluesext.objects.all() \
+            myresultSeriesExport = Timeseriesresultvaluesextwannotations.objects.all() \
                     .filter(resultid__in=selectedMResultSeries).order_by('-valuedatetime')
         emailspreadsheet2(request, myresultSeriesExport, False) # for command str_selectedresultid_ids
         

--- a/soilsIngestionExample/ImportMStoneData.py
+++ b/soilsIngestionExample/ImportMStoneData.py
@@ -4,8 +4,8 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "templatesAndSettings.settings")
 from django.core.wsgi import get_wsgi_application
 application = get_wsgi_application()
 
-import ODM2CZOData.modelHelpers as modelHelpers
-from ODM2CZOData.models import Actions, Units, Variables
+import odm2admin.modelHelpers as modelHelpers
+from odm2admin.models import Actions, Units, Variables
 
 __author__ = 'leonmi'
 

--- a/templatesAndSettings/templates/AddSensor.html
+++ b/templatesAndSettings/templates/AddSensor.html
@@ -121,6 +121,12 @@
             <td><a href="{{ prefixpath }}actions/" class="changelink">{% trans 'Change' %}</a></td>
         </tr>
         <tr>
+            <th scope="row"><a href="{{ prefixpath }}featureactions/">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                {% trans 'Add Feature Action' %}</a></th>
+            <td><a href="{{ prefixpath }}featureactions/add/" class="addlink">{% trans 'Add' %}</a></td>
+            <td><a href="{{ prefixpath }}featureactions/" class="changelink">{% trans 'Change' %}</a></td>
+        </tr>
+        <tr>
             <th scope="row"><a href="{{ prefixpath }}measurementresultvaluefile/">
                 {% trans 'Upload Sensor Data for a single column' %}</a></th>
             <td><a href="{{ prefixpath }}measurementresultvaluefile/add/" class="addlink">{% trans 'Add' %}</a></td>


### PR DESCRIPTION
This update primarily adds data quality codes and annotations to time series exports. The view odm2extra.timeseriesresultvaluesextwannotations has been changed and is now used in the export.  modelHelpers is updated for the folder name change from ODM2CZOData to odm2admin. 