### PR TITLE
Create optional inline for SF based upon its type.

### DIFF
--- a/odm2admin/forms.py
+++ b/odm2admin/forms.py
@@ -17,7 +17,7 @@ from import_export.admin import ExportMixin
 from import_export.admin import ImportExportActionModelAdmin
 from django.db.models import Max
 from .management.commands.ProcessDataLoggerFile import updateStartDateEndDate
-from .models import Actionby
+from .models import Actionby, Specimens
 from .models import Actions
 from .models import Affiliations
 from .models import Authorlists
@@ -776,6 +776,32 @@ class ReadOnlySitesInline(SitesInline):
     def has_add_permission(self, request):
         return False
 
+
+class SpecimensInline(admin.StackedInline):
+    model = Specimens
+    fieldsets = (
+        ('Details', {
+            'classes': ('collapse',),
+            'fields': ('samplingfeatureid',
+                       'specimentypecv',
+                       'specimenmediumcv',
+                       'isfieldspecimen',
+                       )
+        }),
+    )
+    max_num = 1
+    extra = 0
+    min_num = 1
+
+
+class ReadOnlySpecimenInline(SpecimensInline):
+    readonly_fields = SpecimensInline.fieldsets[0][1]['fields']
+    can_delete = False
+
+    def has_add_permission(self, request):
+        return False
+
+
 class IGSNInline(admin.StackedInline):
     model = Samplingfeatureexternalidentifiers
     fieldsets = (
@@ -827,10 +853,39 @@ class ReadOnlySamplingfeatureextensionpropertiesInline(IGSNInline):
 class SamplingfeaturesAdmin(ReadOnlyAdmin):
     # For readonly usergroup
     user_readonly = [p.name for p in Samplingfeatures._meta.get_fields() if not p.one_to_many]
-    user_readonly_inlines = [ReadOnlyFeatureActionsInline, ReadOnlyIGSNInline,ReadOnlySitesInline]
+    user_readonly_inlines = [
+        ReadOnlyFeatureActionsInline,
+        ReadOnlyIGSNInline,
+        ReadOnlySitesInline,
+        ReadOnlySpecimenInline
+    ]
 
     form = SamplingfeaturesAdminForm
-    inlines_list = [FeatureActionsInline, IGSNInline, SamplingfeatureextensionpropertiesInline,SitesInline]
+    inlines_list = [
+        FeatureActionsInline,
+        IGSNInline,
+        SamplingfeatureextensionpropertiesInline,
+        SitesInline,
+        SpecimensInline
+    ]
+
+    def get_formsets_with_inlines(self, request, obj=None):
+        """
+        Yields formsets and the corresponding inlines.
+        """
+        if obj.sampling_feature_type.name == 'Site':
+            print('Site objecttt')
+            filtinline = [item for item in self.get_inline_instances(request, obj)
+                          if item.verbose_name != 'Specimen']
+        elif obj.sampling_feature_type.name == 'Specimen':
+            filtinline = [item for item in self.get_inline_instances(request, obj)
+                          if item.verbose_name != 'Site']
+        else:
+            filtinline = self.get_inline_instances(request, obj)[:-2]
+
+        for inline in filtinline:
+            print(inline.verbose_name)
+            yield inline.get_formset(request, obj), inline
 
     search_fields = ['sampling_feature_type__name', 'sampling_feature_geo_type__name',
                      'samplingfeaturename',

--- a/odm2admin/forms.py
+++ b/odm2admin/forms.py
@@ -873,17 +873,21 @@ class SamplingfeaturesAdmin(ReadOnlyAdmin):
         """
         Yields formsets and the corresponding inlines.
         """
-        if obj.sampling_feature_type.name == 'Site':
-            filtinline = [item for item in self.get_inline_instances(request, obj)
-                          if item.verbose_name != 'Specimen']
-        elif obj.sampling_feature_type.name == 'Specimen':
-            filtinline = [item for item in self.get_inline_instances(request, obj)
-                          if item.verbose_name != 'Site']
-        else:
-            filtinline = self.get_inline_instances(request, obj)[:-2]
+        if obj:
+            if obj.sampling_feature_type.name == 'Site':
+                filtinline = [item for item in self.get_inline_instances(request, obj)
+                              if item.verbose_name != 'Specimen']
+            elif obj.sampling_feature_type.name == 'Specimen':
+                filtinline = [item for item in self.get_inline_instances(request, obj)
+                              if item.verbose_name != 'Site']
+            else:
+                filtinline = self.get_inline_instances(request, obj)[:-2]
 
-        for inline in filtinline:
-            yield inline.get_formset(request, obj), inline
+            for inline in filtinline:
+                yield inline.get_formset(request, obj), inline
+        else:
+            for inline in self.get_inline_instances(request, obj):
+                yield inline.get_formset(request, obj), inline
 
     search_fields = ['sampling_feature_type__name', 'sampling_feature_geo_type__name',
                      'samplingfeaturename',

--- a/odm2admin/forms.py
+++ b/odm2admin/forms.py
@@ -884,7 +884,6 @@ class SamplingfeaturesAdmin(ReadOnlyAdmin):
             filtinline = self.get_inline_instances(request, obj)[:-2]
 
         for inline in filtinline:
-            print(inline.verbose_name)
             yield inline.get_formset(request, obj), inline
 
     search_fields = ['sampling_feature_type__name', 'sampling_feature_geo_type__name',

--- a/odm2admin/forms.py
+++ b/odm2admin/forms.py
@@ -874,7 +874,6 @@ class SamplingfeaturesAdmin(ReadOnlyAdmin):
         Yields formsets and the corresponding inlines.
         """
         if obj.sampling_feature_type.name == 'Site':
-            print('Site objecttt')
             filtinline = [item for item in self.get_inline_instances(request, obj)
                           if item.verbose_name != 'Specimen']
         elif obj.sampling_feature_type.name == 'Specimen':

--- a/odm2admin/models.py
+++ b/odm2admin/models.py
@@ -2514,6 +2514,7 @@ class Specimens(models.Model):
 
     class Meta:
         managed = False
+        verbose_name = 'Specimen'
         db_table = r'odm2"."specimens'
 
 


### PR DESCRIPTION
This addresses @emiliom points:

- The "Change" page for a "core section" specimen sampling feature doesn't include the Specimen section; eg:
  http://dev-odm2admin.cuahsi.org/CZIMEA/odm2admin/samplingfeatures/199/change/

- In those sampling feature pages, the subtypes (Sites or Specimens) sections should not be shown if the sampling feature is not of either type. Currently Sites is always shown.