### PR TITLE
Fix urls in popup

### DIFF
--- a/odm2admin/static/js/Map.js
+++ b/odm2admin/static/js/Map.js
@@ -185,7 +185,7 @@ makerelation = function(relationobs) {
         if (relationobs.children) {
             c = c + "<div class='panel'>" + "<p><ul>";
             relationobs.children.forEach(function (child) {
-                c = c + "<li><a href='/odm2admin/samplingfeatures/" +
+                c = c + "<li><a href='/" + url_path + "odm2admin/samplingfeatures/" +
                     child['samplingfeatureid__samplingfeatureid'] +
                     "/change/'>"+
                     child['samplingfeatureid__samplingfeaturecode'] +
@@ -200,7 +200,7 @@ makerelation = function(relationobs) {
         if (relationobs.parents) {
             p = p + "<div class='panel'>" + "<p><ul>";
             relationobs.parents.forEach(function (child) {
-                p = p + "<li><a href='/odm2admin/samplingfeatures/" +
+                p = p + "<li><a href='/" + url_path + "odm2admin/samplingfeatures/" +
                     child['samplingfeatureid__samplingfeatureid'] +
                     "/change/'>"+
                     child['samplingfeatureid__samplingfeaturecode'] +
@@ -215,7 +215,7 @@ makerelation = function(relationobs) {
         if (relationobs.siblings) {
             s = s + "<div class='panel'>" + "<p><ul>";
             relationobs.siblings.forEach(function (child) {
-                s = s + "<li><a href='/odm2admin/samplingfeatures/" +
+                s = s + "<li><a href='/" + url_path + "odm2admin/samplingfeatures/" +
                     child['samplingfeatureid__samplingfeatureid'] +
                     "/change/'>"+
                     child['samplingfeatureid__samplingfeaturecode'] +


### PR DESCRIPTION
This PR addresses wrong urls in map popups for places with relationships.

@emiliom comment:

> In the map pop-ups, the links to related sampling features under parent/siblings/children features are all wrong. They're missing the "CZIMEA" part of the URL. eg, instead of the above url, this incorrect url is being used:
  http://dev-odm2admin.cuahsi.org/odm2admin/samplingfeatures/199/change/