### PR TITLE
use conda-forge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,7 @@ before_install:
   - conda config --set always_yes yes --set changeps1 no --set show_channel_urls true
   - conda update conda
   - conda config --add channels conda-forge --force
-  - conda config --add channels odm2 --force
-  - conda create --name TEST python=$TRAVIS_PYTHON_VERSION libgdal boost --file requirements.txt --file requirements-dev.txt
+  - conda create --name TEST python=$TRAVIS_PYTHON_VERSION libgdal --file requirements.txt --file requirements-dev.txt
   - source activate TEST
   - pip install --upgrade http://github.com/miguelcleon/django-admin-shortcuts/zipball/master
 


### PR DESCRIPTION
@lsetiawan, @emiliom and @miguelcleon this PR makes use of the conda-forge version of the `odm2` packages. If things are working as expected we can remove the bogus dependency on `boost`b/c, without a 3rd channel, we reduce the channel incompatibilities.